### PR TITLE
Add a simple CI pipeline

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,25 @@
+name: Test with tox
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-env_list = py{39,310,311}
+env_list = py{39,310,311,312}
 minversion = 4.12.1
 
 [testenv]
@@ -17,3 +17,4 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312

--- a/tox.ini
+++ b/tox.ini
@@ -10,3 +10,10 @@ deps =
     pytest>=6
 commands =
     pytest {tty:--color=yes} {posargs}
+
+# Provide a mapping between tox envs and github actions python envs
+[gh-actions]
+python =
+    3.9: py39
+    3.10: py310
+    3.11: py311


### PR DESCRIPTION
Arguably, using tox isn't necessary because github actions will just directly run against multiple python versions but I think it's nice to have because it allows you to run all the tests across 3.9-12 locally before you push rather than bashing your head against the CI.