### PR TITLE
Add kwarg support for CLIArg and subclassing config models with CLIArg fields

### DIFF
--- a/conflator/conflator.py
+++ b/conflator/conflator.py
@@ -17,13 +17,14 @@ from rich_argparse import RawTextRichHelpFormatter
 
 
 class CLIArg:
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         self.args = args
+        self.kwargs = kwargs
         self.description = None
         self.argparse_key = None
 
     def __repr__(self):
-        return f"CLIArg(args = {self.args}, description = {self.description}, argparse_key = {self.argparse_key})"
+        return f"CLIArg(args = {self.args}, kwargs = {self.kwargs}, description = {self.description}, argparse_key = {self.argparse_key})"
 
 
 class EnvVar:
@@ -157,7 +158,7 @@ class Conflator:
                 )
 
             for ca in cli_args:
-                action = self.parser.add_argument(*ca.args, help=ca.description)
+                action = self.parser.add_argument(*ca.args, **ca.kwargs, help=ca.description)
                 ca.argparse_key = action.dest
 
             self.parser.add_argument(

--- a/conflator/conflator.py
+++ b/conflator/conflator.py
@@ -138,7 +138,7 @@ class Conflator:
 
     def load(self) -> BaseModel:
         referenced_models = Conflator._find_models(self.model)
-        #rprint(referenced_models)
+        # rprint(referenced_models)
 
         if self.cli:
             # Find all CLI args and then parse them

--- a/conflator/conflator.py
+++ b/conflator/conflator.py
@@ -117,8 +117,8 @@ class Conflator:
         else:
             if issubclass(t, ConfigModel) and t not in seen:
                 seen.add(t)
-                for k, v in t.__annotations__.items():
-                    Conflator._find_models(v, seen)
+                for v in t.model_fields.values():
+                    Conflator._find_models(v.annotation, seen)
 
         return seen
 
@@ -138,7 +138,7 @@ class Conflator:
 
     def load(self) -> BaseModel:
         referenced_models = Conflator._find_models(self.model)
-        # rprint(referenced_config_models)
+        rprint(referenced_models)
 
         if self.cli:
             # Find all CLI args and then parse them

--- a/conflator/conflator.py
+++ b/conflator/conflator.py
@@ -138,7 +138,7 @@ class Conflator:
 
     def load(self) -> BaseModel:
         referenced_models = Conflator._find_models(self.model)
-        rprint(referenced_models)
+        #rprint(referenced_models)
 
         if self.cli:
             # Find all CLI args and then parse them

--- a/conflator/conflator.py
+++ b/conflator/conflator.py
@@ -24,7 +24,10 @@ class CLIArg:
         self.argparse_key = None
 
     def __repr__(self):
-        return f"CLIArg(args = {self.args}, kwargs = {self.kwargs}, description = {self.description}, argparse_key = {self.argparse_key})"
+        return (
+            f"CLIArg(args = {self.args}, kwargs = {self.kwargs}, "
+            + f"description = {self.description}, argparse_key = {self.argparse_key})"
+        )
 
 
 class EnvVar:

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -12,13 +12,6 @@ class NestedConfig(ConfigModel):
 
     nested_field: Annotated[str, CLIArg("--nested")] = "default_value"
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_nested(cls, data: Any) -> Any:
-        if isinstance(data, str):
-            return {"nested_field": data}
-        return data
-
 
 class ConfigWithCLI(ConfigModel):
     arg1: NestedConfig = NestedConfig()

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,8 +1,7 @@
 from unittest.mock import patch
-from typing import Any
 
 from annotated_types import Annotated
-from pydantic import Field, model_validator, create_model, ConfigDict
+from pydantic import ConfigDict, Field
 
 from conflator import CLIArg, ConfigModel, Conflator, EnvVar
 

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -9,7 +9,7 @@ from conflator import CLIArg, ConfigModel, Conflator, EnvVar
 class NestedConfig(ConfigModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    nested_field: Annotated[str, CLIArg("--nested")] = "default_value"
+    nested_field: Annotated[str, CLIArg("--nested")] = "default_nested"
 
 
 class ConfigWithCLI(ConfigModel):

--- a/tests/test_subclasses.py
+++ b/tests/test_subclasses.py
@@ -17,18 +17,21 @@ class Action(ConfigModel):
 
 class Source(Action):
     "Produces messages"
+
     name: Literal["Source"]
     start_from: str
 
 
 class Process(Action):
     "Processes messages"
+
     name: Literal["Process"]
     should_flub_widgets: bool
 
 
 class Sink(Action):
     "Consumes messages"
+
     name: Literal["Sink"]
     emit_aviso_notification: bool
 


### PR DESCRIPTION
Allow kwargs for cli args and also modified function for finding models to use `model_fields` instead of `__annotations__`, which are not inherited from parent `ConfigModel`. Added test to check cli args from fields in parents are found.