### PR TITLE
build: remove argparse dependency 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/ecmwf/conflator/"
 [tool.poetry.dependencies]
 python = ">3.9"
 pydantic = ">2.0"
-argparse = ">1.0"
 rich-argparse = ">1.0"
 pytest = ">8.0"
 pyyaml = ">6.0"


### PR DESCRIPTION
(argparse is provided in the Python standard library)

Close: #11 