### PR TITLE
Switch Actions organization from ecmwf-actions to ecmwf

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     name: downstream-ci
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     # FIXME: revert to main when ready
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@add-conflator
+    uses: ecmwf/downstream-ci/.github/workflows/downstream-ci.yml@add-conflator
     with:
       conflator: ecmwf/conflator@${{ github.event.pull_request.head.sha || github.sha }}
       codecov_upload: true

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   label:
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/label-pr.yml@v2


### PR DESCRIPTION
Update CI/CD workflows as ecmwf-actions actions have been moved to ecmwf organization.